### PR TITLE
x4 improvement on parsing + Fix the benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ Some benchmark results:
 | `UUID#toString()`               | 3,098,019.503 ± 13,478.983 UUIDs/s   |
 | `FastUUIDParser#toString(UUID)` | 20,992,715.489 ± 113,547.630 UUIDs/s |
 
+## Executing the benchmark
+
+In order to execute the benchmark you can run the following commands:
+
+```bash
+cd fast-uuid
+mvn clean install
+cd benchmark
+mvn clean install -U
+java -jar target/benchmarks.jar
+```
+
+
 ## License
 
 `fast-uuid` is published under the [MIT license](https://github.com/jchambers/fast-uuid/blob/master/LICENSE).

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -59,7 +59,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         </dependency>
         <dependency>
             <groupId>com.eatthepath</groupId>
-            <artifactId>fast-uuid-parser</artifactId>
+            <artifactId>fast-uuid</artifactId>
             <version>0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/benchmark/src/main/java/com/eatthepath/UUIDBenchmark.java
+++ b/benchmark/src/main/java/com/eatthepath/UUIDBenchmark.java
@@ -24,7 +24,7 @@
 
 package com.eatthepath;
 
-import com.eatthepath.uuid.FastUUIDParser;
+import com.eatthepath.uuid.FastUUID;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -60,7 +60,7 @@ public class UUIDBenchmark {
 
     @Benchmark
     public UUID benchmarkUUIDFromFastParser() {
-        return FastUUIDParser.parseUUID(this.uuidStrings[this.i++ % PREGENERATED_UUID_COUNT]);
+        return FastUUID.parseUUID(this.uuidStrings[this.i++ % PREGENERATED_UUID_COUNT]);
     }
 
     @Benchmark
@@ -70,6 +70,6 @@ public class UUIDBenchmark {
 
     @Benchmark
     public String benchmarkFastParserToString() {
-        return FastUUIDParser.toString(this.uuids[this.i++ % PREGENERATED_UUID_COUNT]);
+        return FastUUID.toString(this.uuids[this.i++ % PREGENERATED_UUID_COUNT]);
     }
 }

--- a/src/main/java/com/eatthepath/uuid/FastUUID.java
+++ b/src/main/java/com/eatthepath/uuid/FastUUID.java
@@ -40,7 +40,32 @@ public class FastUUID {
     private static final int UUID_STRING_LENGTH = 36;
 
     private static final char[] HEX_DIGITS =
-            new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+            new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    private static int[] HEX_VALUE = new int[128];
+    static {
+        HEX_VALUE['1'] = 1;
+        HEX_VALUE['2'] = 2;
+        HEX_VALUE['3'] = 3;
+        HEX_VALUE['4'] = 4;
+        HEX_VALUE['5'] = 5;
+        HEX_VALUE['6'] = 6;
+        HEX_VALUE['7'] = 7;
+        HEX_VALUE['8'] = 8;
+        HEX_VALUE['9'] = 9;
+        HEX_VALUE['a'] = 10;
+        HEX_VALUE['A'] = 10;
+        HEX_VALUE['b'] = 11;
+        HEX_VALUE['B'] = 11;
+        HEX_VALUE['c'] = 12;
+        HEX_VALUE['C'] = 12;
+        HEX_VALUE['d'] = 13;
+        HEX_VALUE['D'] = 13;
+        HEX_VALUE['e'] = 14;
+        HEX_VALUE['E'] = 14;
+        HEX_VALUE['f'] = 15;
+        HEX_VALUE['F'] = 15;
+    }
 
     private FastUUID() {
         // A private constructor prevents callers from accidentally instantiating FastUUID instances
@@ -51,83 +76,82 @@ public class FastUUID {
      * {@link UUID#toString()}.
      *
      * @param uuidSequence the character sequence from which to parse a UUID
-     *
      * @return the UUID represented by the given character sequence
-     *
      * @throws IllegalArgumentException if the given character sequence does not conform to the string representation as
-     * described in {@link UUID#toString()}
+     *                                  described in {@link UUID#toString()}
      */
-    public static UUID parseUUID(final CharSequence uuidSequence) {
+    public static UUID parseUUID(final String uuidSequence) {
         if (uuidSequence.length() != UUID_STRING_LENGTH) {
             throw new IllegalArgumentException("Could not parse UUID string: " + uuidSequence);
         }
 
-        long mostSignificantBits = getHexValueForChar(uuidSequence.charAt(0));
+        //final char[] ch = uuidSequence.toCharArray();
+        long mostSignificantBits = HEX_VALUE[uuidSequence.charAt(0)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(1));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(1)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(2));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(2)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(3));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(3)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(4));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(4)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(5));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(5)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(6));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(6)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(7));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(7)];
 
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(9));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(9)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(10));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(10)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(11));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(11)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(12));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(12)];
 
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(14));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(14)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(15));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(15)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(16));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(16)];
         mostSignificantBits <<= 4;
-        mostSignificantBits |= getHexValueForChar(uuidSequence.charAt(17));
+        mostSignificantBits |= HEX_VALUE[uuidSequence.charAt(17)];
 
-        long leastSignificantBits = getHexValueForChar(uuidSequence.charAt(19));
+        long leastSignificantBits = HEX_VALUE[uuidSequence.charAt(19)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(20));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(20)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(21));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(21)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(22));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(22)];
 
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(24));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(24)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(25));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(25)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(26));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(26)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(27));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(27)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(28));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(28)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(29));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(29)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(30));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(30)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(31));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(31)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(32));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(32)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(33));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(33)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(34));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(34)];
         leastSignificantBits <<= 4;
-        leastSignificantBits |= getHexValueForChar(uuidSequence.charAt(35));
+        leastSignificantBits |= HEX_VALUE[uuidSequence.charAt(35)];
 
         return new UUID(mostSignificantBits, leastSignificantBits);
     }
@@ -137,7 +161,6 @@ public class FastUUID {
      * {@link UUID#toString()}.
      *
      * @param uuid the UUID to represent as a string
-     *
      * @return a string representation of the given UUID
      */
     public static String toString(final UUID uuid) {
@@ -146,16 +169,16 @@ public class FastUUID {
 
         final char[] uuidChars = new char[UUID_STRING_LENGTH];
 
-        uuidChars[0]  = HEX_DIGITS[(int) ((mostSignificantBits & 0xf000000000000000L) >>> 60)];
-        uuidChars[1]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x0f00000000000000L) >>> 56)];
-        uuidChars[2]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x00f0000000000000L) >>> 52)];
-        uuidChars[3]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x000f000000000000L) >>> 48)];
-        uuidChars[4]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000f00000000000L) >>> 44)];
-        uuidChars[5]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000f0000000000L) >>> 40)];
-        uuidChars[6]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x000000f000000000L) >>> 36)];
-        uuidChars[7]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000000f00000000L) >>> 32)];
-        uuidChars[8]  = '-';
-        uuidChars[9]  = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000000f0000000L) >>> 28)];
+        uuidChars[0] = HEX_DIGITS[(int) ((mostSignificantBits & 0xf000000000000000L) >>> 60)];
+        uuidChars[1] = HEX_DIGITS[(int) ((mostSignificantBits & 0x0f00000000000000L) >>> 56)];
+        uuidChars[2] = HEX_DIGITS[(int) ((mostSignificantBits & 0x00f0000000000000L) >>> 52)];
+        uuidChars[3] = HEX_DIGITS[(int) ((mostSignificantBits & 0x000f000000000000L) >>> 48)];
+        uuidChars[4] = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000f00000000000L) >>> 44)];
+        uuidChars[5] = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000f0000000000L) >>> 40)];
+        uuidChars[6] = HEX_DIGITS[(int) ((mostSignificantBits & 0x000000f000000000L) >>> 36)];
+        uuidChars[7] = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000000f00000000L) >>> 32)];
+        uuidChars[8] = '-';
+        uuidChars[9] = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000000f0000000L) >>> 28)];
         uuidChars[10] = HEX_DIGITS[(int) ((mostSignificantBits & 0x000000000f000000L) >>> 24)];
         uuidChars[11] = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000000000f00000L) >>> 20)];
         uuidChars[12] = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000000000f0000L) >>> 16)];
@@ -163,38 +186,27 @@ public class FastUUID {
         uuidChars[14] = HEX_DIGITS[(int) ((mostSignificantBits & 0x000000000000f000L) >>> 12)];
         uuidChars[15] = HEX_DIGITS[(int) ((mostSignificantBits & 0x0000000000000f00L) >>> 8)];
         uuidChars[16] = HEX_DIGITS[(int) ((mostSignificantBits & 0x00000000000000f0L) >>> 4)];
-        uuidChars[17] = HEX_DIGITS[(int)  (mostSignificantBits & 0x000000000000000fL)];
+        uuidChars[17] = HEX_DIGITS[(int) (mostSignificantBits & 0x000000000000000fL)];
         uuidChars[18] = '-';
-        uuidChars[19]  = HEX_DIGITS[(int) ((leastSignificantBits & 0xf000000000000000L) >>> 60)];
-        uuidChars[20]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x0f00000000000000L) >>> 56)];
-        uuidChars[21]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x00f0000000000000L) >>> 52)];
-        uuidChars[22]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x000f000000000000L) >>> 48)];
+        uuidChars[19] = HEX_DIGITS[(int) ((leastSignificantBits & 0xf000000000000000L) >>> 60)];
+        uuidChars[20] = HEX_DIGITS[(int) ((leastSignificantBits & 0x0f00000000000000L) >>> 56)];
+        uuidChars[21] = HEX_DIGITS[(int) ((leastSignificantBits & 0x00f0000000000000L) >>> 52)];
+        uuidChars[22] = HEX_DIGITS[(int) ((leastSignificantBits & 0x000f000000000000L) >>> 48)];
         uuidChars[23] = '-';
-        uuidChars[24]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000f00000000000L) >>> 44)];
-        uuidChars[25]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000f0000000000L) >>> 40)];
-        uuidChars[26]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x000000f000000000L) >>> 36)];
-        uuidChars[27]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000000f00000000L) >>> 32)];
-        uuidChars[28]  = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000000f0000000L) >>> 28)];
+        uuidChars[24] = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000f00000000000L) >>> 44)];
+        uuidChars[25] = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000f0000000000L) >>> 40)];
+        uuidChars[26] = HEX_DIGITS[(int) ((leastSignificantBits & 0x000000f000000000L) >>> 36)];
+        uuidChars[27] = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000000f00000000L) >>> 32)];
+        uuidChars[28] = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000000f0000000L) >>> 28)];
         uuidChars[29] = HEX_DIGITS[(int) ((leastSignificantBits & 0x000000000f000000L) >>> 24)];
         uuidChars[30] = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000000000f00000L) >>> 20)];
         uuidChars[31] = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000000000f0000L) >>> 16)];
         uuidChars[32] = HEX_DIGITS[(int) ((leastSignificantBits & 0x000000000000f000L) >>> 12)];
         uuidChars[33] = HEX_DIGITS[(int) ((leastSignificantBits & 0x0000000000000f00L) >>> 8)];
         uuidChars[34] = HEX_DIGITS[(int) ((leastSignificantBits & 0x00000000000000f0L) >>> 4)];
-        uuidChars[35] = HEX_DIGITS[(int)  (leastSignificantBits & 0x000000000000000fL)];
+        uuidChars[35] = HEX_DIGITS[(int) (leastSignificantBits & 0x000000000000000fL)];
 
         return new String(uuidChars);
     }
-
-    static int getHexValueForChar(final char c) {
-        if (c >= '0' && c <= '9') {
-            return c - 48;
-        } else if (c >= 'a' && c <= 'f') {
-            return c - 87;
-        } else if (c >= 'A' && c <= 'F') {
-            return c - 55;
-        } else {
-            throw new IllegalArgumentException("Illegal hexadecimal digit: " + c);
-        }
-    }
 }
+

--- a/src/test/java/com/eatthepath/uuid/FastUUIDTest.java
+++ b/src/test/java/com/eatthepath/uuid/FastUUIDTest.java
@@ -48,37 +48,6 @@ public class FastUUIDTest {
         final UUID uuid = UUID.randomUUID();
         assertEquals(uuid.toString(), FastUUID.toString(uuid));
     }
-
-    @Test
-    public void testGetHexValueForChar() {
-        assertEquals(0, FastUUID.getHexValueForChar('0'));
-        assertEquals(1, FastUUID.getHexValueForChar('1'));
-        assertEquals(2, FastUUID.getHexValueForChar('2'));
-        assertEquals(3, FastUUID.getHexValueForChar('3'));
-        assertEquals(4, FastUUID.getHexValueForChar('4'));
-        assertEquals(5, FastUUID.getHexValueForChar('5'));
-        assertEquals(6, FastUUID.getHexValueForChar('6'));
-        assertEquals(7, FastUUID.getHexValueForChar('7'));
-        assertEquals(8, FastUUID.getHexValueForChar('8'));
-        assertEquals(9, FastUUID.getHexValueForChar('9'));
-
-        assertEquals(10, FastUUID.getHexValueForChar('a'));
-        assertEquals(11, FastUUID.getHexValueForChar('b'));
-        assertEquals(12, FastUUID.getHexValueForChar('c'));
-        assertEquals(13, FastUUID.getHexValueForChar('d'));
-        assertEquals(14, FastUUID.getHexValueForChar('e'));
-        assertEquals(15, FastUUID.getHexValueForChar('f'));
-
-        assertEquals(10, FastUUID.getHexValueForChar('A'));
-        assertEquals(11, FastUUID.getHexValueForChar('B'));
-        assertEquals(12, FastUUID.getHexValueForChar('C'));
-        assertEquals(13, FastUUID.getHexValueForChar('D'));
-        assertEquals(14, FastUUID.getHexValueForChar('E'));
-        assertEquals(15, FastUUID.getHexValueForChar('F'));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetHexValueForCharIllegalChar() {
-        FastUUID.getHexValueForChar('x');
-    }
+    
 }
+


### PR DESCRIPTION
You can improve the parsing by 4 times by using a lookup table instead of an if/else branching to compute the hex value of a char.

```java
    private static int[] HEX_VALUE = new int[128];
    static {
        HEX_VALUE['0'] = 0;
        HEX_VALUE['1'] = 1;
        HEX_VALUE['2'] = 2;
        HEX_VALUE['3'] = 3;
        HEX_VALUE['4'] = 4;
        HEX_VALUE['5'] = 5;
        HEX_VALUE['6'] = 6;
        HEX_VALUE['7'] = 7;
        HEX_VALUE['8'] = 8;
        HEX_VALUE['9'] = 9;
        HEX_VALUE['a'] = 10;
        HEX_VALUE['A'] = 10;
        HEX_VALUE['b'] = 11;
        HEX_VALUE['B'] = 11;
        HEX_VALUE['c'] = 12;
        HEX_VALUE['C'] = 12;
        HEX_VALUE['d'] = 13;
        HEX_VALUE['D'] = 13;
        HEX_VALUE['e'] = 14;
        HEX_VALUE['E'] = 14;
        HEX_VALUE['f'] = 15;
        HEX_VALUE['F'] = 15;
    }
```

Then just use `HEX_VALUE[uuidSequence.charAt(X)];` instead of `getHexValueForChar(uuidSequence.charAt(X))`.

Benchmark pom project was fixed because it pointed to a `fast-uuid-parser` which is named `fast-uuid`.
I also removed some tests since the `getHexValueForChar` is now deleted.
Readme has been updated in order to explain how to run the benchmarks (for those who don't know jmh).

Benchmarks on my machine:

*Before*
```
Benchmark                                   Mode  Cnt         Score        Error  Units
UUIDBenchmark.benchmarkFastParserToString  thrpt   40  18850285,268 ± 292260,574  ops/s
UUIDBenchmark.benchmarkUUIDFromFastParser  thrpt   40   5430137,326 ± 354801,493  ops/s
UUIDBenchmark.benchmarkUUIDFromString      thrpt   40   1319052,901 ± 101011,389  ops/s
UUIDBenchmark.benchmarkUUIDToString        thrpt   40   2581791,612 ± 114785,630  ops/s
```
*After*
```
Benchmark                                   Mode  Cnt         Score        Error  Units
UUIDBenchmark.benchmarkFastParserToString  thrpt   40  18154539,206 ± 617354,677  ops/s
UUIDBenchmark.benchmarkUUIDFromFastParser  thrpt   40  23199948,837 ± 638756,033  ops/s
UUIDBenchmark.benchmarkUUIDFromString      thrpt   40   1359176,406 ±  44637,824  ops/s
UUIDBenchmark.benchmarkUUIDToString        thrpt   40   2468160,559 ± 158349,184  ops/s
```

Let's find some ways to make it even faster ;-)