### PR TITLE
Look up hex values in an array instead calculating them repeatedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # fast-uuid
 
-`fast-uuid` is a Java library for quickly and efficiently parsing and writing UUIDs. In benchmarks, it's a little more than four times faster at parsing UUIDs and six times faster at writing UUIDs than the stock JDK implementation. It is intended for applications that work with large quantities of UUIDs or that work with UUIDs in performance-sensitive code.
+`fast-uuid` is a Java library for quickly and efficiently parsing and writing UUIDs. In benchmarks, it's a little more than thirteen times faster at parsing UUIDs and six times faster at writing UUIDs than the stock JDK implementation. It is intended for applications that work with large quantities of UUIDs or that work with UUIDs in performance-sensitive code.
 
 ## Usage
 
@@ -58,10 +58,10 @@ That leaves the first problem: can we find a way to parse a UUID without breakin
 
 Here are some benchmark results:
 
-| Benchmark                          | Throughput                              |
-|------------------------------------|-----------------------------------------|
-| `UUID#fromString(String)`          | 1,633,510.644 ± 10,136.510 UUIDs/second |
-| `FastUUIDParser#parseUUID(String)` | 6,691,400.272 ± 43,419.636 UUIDs/second |
+| Benchmark                          | Throughput                                |
+|------------------------------------|-------------------------------------------|
+| `UUID#fromString(String)`          | 1,402,809.639 ± 47,330.410 UUIDs/second   |
+| `FastUUIDParser#parseUUID(String)` | 18,526,217.851 ± 292,822.631 UUIDs/second |
 
 ### UUIDs to strings
 
@@ -95,8 +95,8 @@ Some benchmark results:
 
 | Benchmark                       | Throughput                           |
 |---------------------------------|--------------------------------------|
-| `UUID#toString()`               | 3,098,019.503 ± 13,478.983 UUIDs/s   |
-| `FastUUIDParser#toString(UUID)` | 20,992,715.489 ± 113,547.630 UUIDs/s |
+| `UUID#toString()`               | 2,620,931.697 ± 21,127.934 UUIDs/s   |
+| `FastUUIDParser#toString(UUID)` | 17,449,400.607 ± 221,381.917 UUIDs/s |
 
 ## License
 

--- a/src/main/java/com/eatthepath/uuid/FastUUID.java
+++ b/src/main/java/com/eatthepath/uuid/FastUUID.java
@@ -42,6 +42,39 @@ public class FastUUID {
     private static final char[] HEX_DIGITS =
             new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
+    private static final int[] HEX_VALUES = new int[128];
+
+    static {
+        for (int i = 0; i < HEX_VALUES.length; i++) {
+            HEX_VALUES[i] = -1;
+        }
+
+        HEX_VALUES['0'] = 0x0;
+        HEX_VALUES['1'] = 0x1;
+        HEX_VALUES['2'] = 0x2;
+        HEX_VALUES['3'] = 0x3;
+        HEX_VALUES['4'] = 0x4;
+        HEX_VALUES['5'] = 0x5;
+        HEX_VALUES['6'] = 0x6;
+        HEX_VALUES['7'] = 0x7;
+        HEX_VALUES['8'] = 0x8;
+        HEX_VALUES['9'] = 0x9;
+
+        HEX_VALUES['a'] = 0xa;
+        HEX_VALUES['b'] = 0xb;
+        HEX_VALUES['c'] = 0xc;
+        HEX_VALUES['d'] = 0xd;
+        HEX_VALUES['e'] = 0xe;
+        HEX_VALUES['f'] = 0xf;
+
+        HEX_VALUES['A'] = 0xa;
+        HEX_VALUES['B'] = 0xb;
+        HEX_VALUES['C'] = 0xc;
+        HEX_VALUES['D'] = 0xd;
+        HEX_VALUES['E'] = 0xe;
+        HEX_VALUES['F'] = 0xf;
+    }
+
     private FastUUID() {
         // A private constructor prevents callers from accidentally instantiating FastUUID instances
     }
@@ -187,14 +220,14 @@ public class FastUUID {
     }
 
     static int getHexValueForChar(final char c) {
-        if (c >= '0' && c <= '9') {
-            return c - 48;
-        } else if (c >= 'a' && c <= 'f') {
-            return c - 87;
-        } else if (c >= 'A' && c <= 'F') {
-            return c - 55;
-        } else {
+        try {
+            if (HEX_VALUES[c] < 0) {
+                throw new IllegalArgumentException("Illegal hexadecimal digit: " + c);
+            }
+        } catch (final ArrayIndexOutOfBoundsException e) {
             throw new IllegalArgumentException("Illegal hexadecimal digit: " + c);
         }
+
+        return HEX_VALUES[c];
     }
 }


### PR DESCRIPTION
This implements almost exactly the same approach as #3, but includes a little more error checking. In benchmarks, this approach is about 5% slower than @agrison's, but it's still roughly a 4x improvement over `master` (which was itself a 4x improvement over the stock implementation).